### PR TITLE
add libjpeg-dev

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -11,7 +11,7 @@ sudo add-apt-repository ppa:deadsnakes/ppa -y
 
 sudo apt update -y && sudo apt full-upgrade -y && sudo apt autoremove -y && sudo apt clean -y && sudo apt autoclean -y
 
-sudo apt install acl unattended-upgrades snapd zsh git-core keychain mosh gcc gparted ubuntu-drivers-common python3.9 python3.9-dev python3.9-distutils python3-distutils ncdu x11-apps xclip xsel build-essential devscripts debhelper fakeroot locate ffmpeg libsm6 libxext6 parallel curl gnupg lsb-release ca-certificates alsa-base alsa-utils awscli tmux gcc-10 g++-10 -y
+sudo apt install acl unattended-upgrades snapd zsh git-core keychain mosh gcc gparted ubuntu-drivers-common python3.9 python3.9-dev python3.9-distutils python3-distutils ncdu x11-apps xclip xsel build-essential devscripts debhelper fakeroot locate ffmpeg libsm6 libxext6 parallel curl gnupg lsb-release ca-certificates alsa-base alsa-utils awscli tmux gcc-10 g++-10 libjpeg-dev -y
 sudo updatedb
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3.9 get-pip.py


### PR DESCRIPTION
```
Collecting jpegtran-cffi
        Using cached jpegtran-cffi-0.5.2.tar.gz (138 kB)
        Preparing metadata (setup.py): started
        Preparing metadata (setup.py): finished with status 'error'
        error: subprocess-exited-with-error

        × python setup.py egg_info did not run successfully.
        │ exit code: 1
        ╰─> [67 lines of output]
            In file included from jpegtran/__pycache__/_cffi__xd2d84bdexcdb1023.c:267:
            src/epeg_private.h:14:10: fatal error: jpeglib.h: No such file or directory
               14 | #include <jpeglib.h>
                  |          ^~~~~~~~~~~
            compilation terminated.
```