### PR TITLE
zero interaction

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DEBIAN_FRONTEND=noninteractive
+
 # add opendns DNS (else the ppa's sometimes can't be resolved)
 sudo apt -y remove needrestart
 sudo apt update -y


### PR DESCRIPTION
"noninteractive – You use this mode when you need zero interaction while installing or upgrading the system via apt. It accepts the default answer for all questions. It might mail an error message to the root user, but that’s it all. Otherwise, it is totally silent and humble, a perfect frontend for automatic installs. one can use such mode in Dockerfile, shell scripts, cloud-init script, and more."
ref: https://www.cyberciti.biz/faq/explain-debian_frontend-apt-get-variable-for-ubuntu-debian/